### PR TITLE
defined types of modals and created two  success modals

### DIFF
--- a/client/src/components/Modals/ModalTypes.js
+++ b/client/src/components/Modals/ModalTypes.js
@@ -1,0 +1,66 @@
+//TODO: confirm(), cancel(), close() are for testing, change all function calls for confirmAction and cancelAction
+function confirm() {
+  console.log("confirm() in MUIModalTypes called - not implemented");
+}
+function cancel() {
+  console.log("cancel() in MUIModalTypes called - not implemented");
+}
+function close() {
+  console.log("close() in MUIModalTypes called - not implemented");
+}
+
+export const ConfirmModalTypes = {
+  DELETE_MAP: {
+    name: "DELETE_MAP",
+    title: "Delete Map",
+    text: "Are you sure you want to delete ",
+    warning: "After the map is deleted, it can no longer be recovered",
+    confirmAction: confirm,
+    cancelAction: cancel,
+  },
+  DELETE_LAYER: {
+    name: "DELETE_LAYER",
+    title: "Delete Layer",
+    text: "Are you sure you want to delete ",
+    warning: "After the layer is deleted, it can no longer be recovered",
+    confirmAction: confirm,
+    cancelAction: cancel,
+  },
+  PUBLISH_MAP: {
+    name: "PUBLISH_MAP",
+    title: "Publish Map",
+    text: "Are you sure you want to publish ",
+    warning: "After the map is published, you can no longer edit it",
+    confirmAction: confirm,
+    cancelAction: cancel,
+  },
+};
+
+export const SuccessModalTypes = {
+  MESSAGE_SUCCESS: {
+    name: "MESSAGE_SUCCESS",
+    text: "Message sent to ",
+    subtext: "",
+    close: close,
+  },
+  PUBLISH_SUCCESS: {
+    name: "PUBLISH_SUCCESS",
+    text: "Successfully published ",
+    subtext: "Your vision, Mapped out.",
+    close: close,
+  },
+};
+export const InputModalTypes = {
+  RENAME_MAP: {
+    name: "RENAME_MAP",
+    title: "Rename Map",
+    confirmAction: confirm,
+    cancelAction: cancel,
+  },
+  MESSAGE_MODAL: {
+    name: "MESSAGE_MODAL",
+    title: "Message to ",
+    confirmAction: confirm,
+    cancelAction: cancel,
+  },
+};

--- a/client/src/components/Modals/SuccessModal.js
+++ b/client/src/components/Modals/SuccessModal.js
@@ -1,0 +1,36 @@
+import { useState, useEffect } from "react";
+import * as React from "react";
+import Alert from "@mui/material/Alert";
+import Snackbar from "@mui/material/Snackbar";
+
+//Modal that displays a message in the lower-left of the screen for 5sec, with an option to prematurely close the modal
+//Example of a way to create a SuccessModal, see ModalTypes.js for definition of "SuccessModalTypes.MESSAGE_SUCCESS":
+//<SuccessModal
+//  modalType={SuccessModalTypes.MESSAGE_SUCCESS}
+// ></SuccessModal>
+
+export default function SuccessModal(props) {
+  const { modalType } = props;
+  const [open, setOpen] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setOpen(false);
+    }, 5000);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <Snackbar
+      open={open}
+      autoHideDuration={5000}
+      onClose={() => setOpen(false)}
+    >
+      <Alert onClose={() => setOpen(false)} severity="success">
+        {modalType.text + "MYMAP"}
+        {". " + modalType.subtext}
+      </Alert>
+    </Snackbar>
+  );
+}


### PR DESCRIPTION
Defined three general categories of modals (confirm modal, success modal, input modal) in ModalTypes.js

Created a Success Modal component that shows an alert for 5 seconds to notify the user that the action was successfully confirmed. So far, Success Modal works for displaying publish map success, and successfully sending a message to another user.
![image](https://github.com/AmyLin06/MapArtisan/assets/43829072/8d98895a-cdde-43c6-8027-f32dcf6be89d)
![image](https://github.com/AmyLin06/MapArtisan/assets/43829072/2c28df2c-3dbb-40b8-b51e-ba96586486f7)


