### PR TITLE
Added Banner for edit screen, logo and banner bg are the same color, …

### DIFF
--- a/client/src/components/Banner.js
+++ b/client/src/components/Banner.js
@@ -12,6 +12,7 @@ export default function Banner(props) {
   const { screen } = props;
   var middleOfBanner = <></>;
   var rightOfBanner = <></>;
+  var bannerColor = "transparent";
 
   const communityScreenStyle = {
     fontFamily: "Londrina Outline, sans-serif",
@@ -126,11 +127,28 @@ export default function Banner(props) {
         <div style={communityScreenStyle}>MapArtisan Community</div>
       );
       break;
+    case "EDIT":
+      rightOfBanner = (
+        <Stack spacing={2.5} direction="row">
+          <Avatar sx={{ bgcolor: "#246BAD" }}>
+            <GroupsIcon style={{ fontSize: "2rem" }} />
+          </Avatar>
+          <Avatar sx={{ bgcolor: red[500] }} aria-label="recipe">
+            R
+          </Avatar>
+        </Stack>
+      );
+      bannerColor = "#246BAD";
+      break;
     default:
       break;
   }
   return (
-    <Grid container spacing={2} sx={{ paddingBottom: 3 }}>
+    <Grid
+      container
+      spacing={2}
+      sx={{ paddingBottom: 3, backgroundColor: bannerColor }}
+    >
       <Grid item xs={2}>
         <CustomButton text="Logo here" />
       </Grid>


### PR DESCRIPTION
Added a banner for the Edit Screen. However, the temporary logo is the same color as the banner background color, so the logo is not visible. 

Banner for Edit Screen:
![image](https://github.com/AmyLin06/MapArtisan/assets/43829072/6fc64d88-d6dd-45c0-a5b0-2b310adef894)
